### PR TITLE
README: Mentioned required Docker Compose version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ OpenLMIS 3.x Independent Service.
 
 ## Prerequisites
 * Docker 1.11+
+* Docker Compose 1.6+
 
 ## Quick Start
 


### PR DESCRIPTION
Ran into https://github.com/docker/compose/issues/3209 - since compose syntax 2 is used, Compose 1.6 is required. Source: https://blog.docker.com/2016/02/compose-1-6/.
